### PR TITLE
Devcontainer environment for duckietown developers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,8 +36,11 @@ RUN sudo apt-get update \
     direnv \
     dnsutils \
     inetutils-ping \
+    inetutils-traceroute \
     nano \
     net-tools \
+    python3.8-venv \
+    pipx \
     rsync \
     unzip \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,6 +43,7 @@ RUN sudo apt-get update \
     pipx \
     rsync \
     unzip \
+    myrepos \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # Configure direnv shell hook (assuming bash)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 		// "source=/var/run/avahi-daemon/socket,target=/var/run/avahi-daemon/socket,type=bind",
 		// ++++++++++++++++++++++++
 	],
-	"postCreateCommand": ".devcontainer/postCreateCommand.sh",
+	"postCreateCommand": "chmod +x .devcontainer/postCreateCommand.sh && .devcontainer/postCreateCommand.sh",
 	"onCreateCommand": "git submodule update --init .devcontainer/feature-dts-devcontainer", // Make sure the dts feature is initialized
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 		"source=/var/run/avahi-daemon/socket,target=/var/run/avahi-daemon/socket,type=bind",
 		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind"
 	],
-	"postCreateCommand": "catkin_make --pkg duckietown_msgs --source /ente/robot/dt-ros-commons/packages --build /home/vscode/build && source /ente/devel/setup.bash",
+	"postCreateCommand": "./postCreateCommand.sh",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"moby": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,7 @@
 		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind"
 	],
 	"postCreateCommand": ".devcontainer/postCreateCommand.sh",
+	"onCreateCommand": "git submodule update --init .devcontainer/feature-dts-devcontainer", // Make sure the dts feature is initialized
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"moby": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
 		"source=/var/run/avahi-daemon/socket,target=/var/run/avahi-daemon/socket,type=bind",
 		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind"
 	],
-  	"features": {
+	"postCreateCommand": "catkin_make --pkg duckietown_msgs --source /ente/robot/dt-ros-commons/packages --build /home/vscode/build && source /ente/devel/setup.bash",
+	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"moby": true,
 			"azureDnsAutoDetection": true,
@@ -43,7 +44,10 @@
 				"ms-toolsai.jupyter",
 				"ms-toolsai.jupyter-cell-tags",
 				"ms-toolsai.jupyter-renderers",
-				"ms-toolsai.vscode-jupyter-slideshow"
+				"ms-toolsai.vscode-jupyter-slideshow",
+				"Tyriar.luna-paint",
+				"eamodio.gitlens",
+				// "ms-iot.vscode-ros"
 			]
 		}
 	}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 		"source=/var/run/avahi-daemon/socket,target=/var/run/avahi-daemon/socket,type=bind",
 		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind"
 	],
-	"postCreateCommand": "./postCreateCommand.sh",
+	"postCreateCommand": ".devcontainer/postCreateCommand.sh",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"moby": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,9 +9,10 @@
 	"workspaceFolder": "/${localWorkspaceFolderBasename}",
   	"mounts": [
     	"source=${localEnv:HOME}${localEnv:USERPROFILE}/.bash_history,target=/home/vscode/.bash_history,type=bind",
-		"source=/var/run/dbus,target=/var/run/dbus,type=bind",
-		"source=/var/run/avahi-daemon/socket,target=/var/run/avahi-daemon/socket,type=bind",
-		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind"
+		// +++++++++++++ NOTE: uncomment if running on linux host
+		// "source=/var/run/dbus,target=/var/run/dbus,type=bind",
+		// "source=/var/run/avahi-daemon/socket,target=/var/run/avahi-daemon/socket,type=bind",
+		// ++++++++++++++++++++++++
 	],
 	"postCreateCommand": ".devcontainer/postCreateCommand.sh",
 	"onCreateCommand": "git submodule update --init .devcontainer/feature-dts-devcontainer", // Make sure the dts feature is initialized

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,6 +1,6 @@
 direnv allow /dt-env-developer
 make mrtrust-all
 mr checkout
-# Build and install the dt-ros-commons packages
+# Build and install the duckietown_msgs packages
 catkin_make --pkg duckietown_msgs --source /dt-env-developer/robot/dt-ros-commons/packages --build /home/vscode/build
-source /dt-env-developer/devel/setup.bash
+. /dt-env-developer/devel/setup.bash

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,3 @@
+catkin_make --pkg duckietown_msgs --source /ente/robot/dt-ros-commons/packages --build /home/vscode/build
+direnv allow /ente
+source /ente/devel/setup.bash

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -2,5 +2,5 @@ direnv allow /dt-env-developer
 make mrtrust-all
 mr checkout
 # Build and install the duckietown_msgs packages
-catkin_make --pkg duckietown_msgs --source /dt-env-developer/robot/dt-ros-commons/packages --build /home/vscode/build
-. /dt-env-developer/devel/setup.bash
+# catkin_make --pkg duckietown_msgs --source /dt-env-developer/robot/dt-ros-commons/packages --build /home/vscode/build
+# . /dt-env-developer/devel/setup.bash

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,3 +1,6 @@
-catkin_make --pkg duckietown_msgs --source /ente/robot/dt-ros-commons/packages --build /home/vscode/build
-direnv allow /ente
-source /ente/devel/setup.bash
+direnv allow /dt-env-developer
+make mrtrust-all
+mr checkout
+# Build and install the dt-ros-commons packages
+catkin_make --pkg duckietown_msgs --source /dt-env-developer/robot/dt-ros-commons/packages --build /home/vscode/build
+source /dt-env-developer/devel/setup.bash

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ jenkins-jobs
 db-production2
 
 /sandbox/*
+devel/*
+.catkin_workspace

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".devcontainer/feature-dts-devcontainer"]
 	path = .devcontainer/feature-dts-devcontainer
-	url = https://github.com/duckietown/feature-dts-devcontainer.git
+	url = ssh://github.com/duckietown/feature-dts-devcontainer.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".devcontainer/feature-dts-devcontainer"]
 	path = .devcontainer/feature-dts-devcontainer
-	url = git@github.com:duckietown/feature-dts-devcontainer.git
+	url = https://github.com/duckietown/feature-dts-devcontainer.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".devcontainer/feature-dts-devcontainer"]
 	path = .devcontainer/feature-dts-devcontainer
-	url = git@github.com:duckietown/feature-dts-devcontainer.git
+	url = http://github.com:duckietown/feature-dts-devcontainer.git

--- a/README.md
+++ b/README.md
@@ -127,7 +127,10 @@ sudo systemctl restart sshd
 1. Open Visual Studio Code.
 2. Install the "Remote - Containers" extension if you haven't already.
 3. Open the repository folder in Visual Studio Code.
-4. Press `F1` and select `Remote-Containers: Open Folder in Container...`.
-5. Select the repository folder.
+4. Download the dts module for the devcontainer by running:
+
+        git submodule update --init .devcontainer/feature-dts-devcontainer
+
+5. Press `F1` and select `Dev Containers: Rebuild and Reopen in Container`.
 
 

--- a/README.md
+++ b/README.md
@@ -95,3 +95,39 @@ Switch your shell to `ente` by running the following command,
 dts --set-version ente
 ```
 
+## Devcontainer usage
+
+This repository can be used as a devcontainer for development. This allows you to avoid installing anything on your local os. The only dependency is Docker. Follow the following steps to start the devcontainer:
+
+> [!IMPORTANT]
+> To utilize the full functionalities of the devcontainer (specifically host network) on macOS, you need to install `orbstack` rather than Docker. Follow the installation instructions [here](https://docs.orbstack.dev/quick-start).
+> After installing `orbstack`, make sure it is running before opening the repository in a devcontainer.
+
+### 1. Setup SSH Key Authentication
+
+Ensure you have SSH key authentication set up with GitHub. You can follow the instructions [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh).
+
+### 2. Enable SSH Agent Forwarding
+
+Edit your `/etc/ssh/sshd_config` file to enable SSH agent forwarding. Add or modify the following lines:
+
+```
+AllowAgentForwarding yes
+```
+
+Restart the SSH service to apply the changes (**linux only**):
+
+```
+sudo systemctl restart sshd
+```
+
+### 3. Open the Repository in a Devcontainer
+
+
+1. Open Visual Studio Code.
+2. Install the "Remote - Containers" extension if you haven't already.
+3. Open the repository folder in Visual Studio Code.
+4. Press `F1` and select `Remote-Containers: Open Folder in Container...`.
+5. Select the repository folder.
+
+

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ sudo systemctl restart sshd
 1. Open Visual Studio Code.
 2. Install the "Remote - Containers" extension if you haven't already.
 3. Open the repository folder in Visual Studio Code.
+    > [!IMPORTANT]
+    > If running on a linux host open the `.devcontainer/devcontainer.json` file and uncomment lines 13-14.
+
 4. Download the dts module for the devcontainer by running:
 
         git submodule update --init .devcontainer/feature-dts-devcontainer


### PR DESCRIPTION
I have added a devcontainer to the repository, it can be helpful to streamline and unify the development workflow. It provides a ros environment based on Ubuntu 20.04 with the duckietown shell installed and support for deployments on robots (mDNS discovery working).

Instructions to deploy are in the README.md.

There are some minor differences in setup between mac and linux, it might be best to remove these before merging.
One naive way to do so would be to create the directories `/var/run/dbus` and `/var/run/avahi-daemon/socket` on macOS machines. In this way we can unify the `devcontainer.json` file for the two platforms. I actually don't remember why we need the former but the latter is required to enable mDNS on linux machines. On macOS mDNS is already provided by orbstack and the native network stack of the OS resolves the `.local` domain using Bonjour.