### PR TITLE
Create universal devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -53,5 +53,9 @@ RUN echo 'eval "$(direnv hook bash)"' >> ~/.bashrc \
     && echo 'export PIPX_BIN_DIR="$HOME/.local/bin"' >> ~/.bashrc \
     && echo 'export PATH="$PIPX_BIN_DIR:$PATH"' >> ~/.bashrc
 
+# Install mutagen
+RUN curl -sS https://webi.sh/mutagen | sh \
+    && source ~/.config/envman/PATH.env
+
 RUN mkdir -p /home/vscode/.local/bin
 RUN sudo chown -R $USERNAME:$USERNAME /home/$USERNAME

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,6 +41,7 @@ RUN sudo apt-get update \
     inetutils-ping \
     iproute2 \
     libnss3-tools \
+    libnss-mdns \
     mr \
     nano \
     net-tools \
@@ -53,6 +54,10 @@ RUN sudo apt-get update \
     gcc \
     python3-dev \
     && sudo rm -rf /var/lib/apt/lists/*
+
+# Configure mDNS for fast .local resolution
+# Use mdns_minimal which only queries mDNS for .local domains, avoiding DNS timeouts
+RUN sudo sed -i 's/^hosts:.*/hosts: files mdns_minimal [NOTFOUND=return] dns/' /etc/nsswitch.conf
 
 
 # Install Firefox from Mozilla repository

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,6 +38,7 @@ RUN sudo apt-get update \
     inetutils-ping \
     nano \
     net-tools \
+    openssh-client \
     rsync \
     unzip \
     pipx \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -54,10 +54,6 @@ RUN sudo apt-get update \
     python3-dev \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Configure mDNS for fast .local resolution
-RUN sudo sed -i 's/hosts:.*/hosts: files myhostname mdns4_minimal [NOTFOUND=return] dns/' /etc/nsswitch.conf
-
-
 # Install Firefox from Mozilla repository
 ARG DEBIAN_FRONTEND=noninteractive
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,6 +40,7 @@ RUN sudo apt-get update \
     git \
     inetutils-ping \
     iproute2 \
+    libnss3-tools \
     nano \
     net-tools \
     openssh-client \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -55,8 +55,7 @@ RUN sudo apt-get update \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # Configure mDNS for fast .local resolution
-# Use mdns_minimal which only queries mDNS for .local domains, avoiding DNS timeouts
-RUN sudo sed -i 's/^hosts:.*/hosts: files mdns_minimal [NOTFOUND=return] dns/' /etc/nsswitch.conf
+RUN sudo sed -i 's/hosts:.*/hosts: files myhostname mdns4_minimal [NOTFOUND=return] dns/' /etc/nsswitch.conf
 
 
 # Install Firefox from Mozilla repository

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,6 +36,7 @@ RUN sudo apt-get update \
     curl \
     direnv \
     dnsutils \
+    fuse \
     git \
     inetutils-ping \
     iproute2 \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -52,6 +52,22 @@ RUN sudo apt-get update \
     python3-dev \
     && sudo rm -rf /var/lib/apt/lists/*
 
+
+# Install Firefox from Mozilla repository
+ARG DEBIAN_FRONTEND=noninteractive
+RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+        ca-certificates wget gnupg lsb-release && \
+    sudo install -d -m 0755 /etc/apt/keyrings && \
+    wget -qO- https://packages.mozilla.org/apt/repo-signing-key.gpg \
+      | sudo gpg --dearmor -o /etc/apt/keyrings/packages.mozilla.org.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.gpg] https://packages.mozilla.org/apt mozilla main" \
+      | sudo tee /etc/apt/sources.list.d/mozilla.list > /dev/null && \
+    echo 'Package: *\nPin: origin packages.mozilla.org\nPin-Priority: 1000' \
+      | sudo tee /etc/apt/preferences.d/mozilla > /dev/null && \
+    sudo apt-get update && \
+    sudo apt-get install -y --no-install-recommends firefox && \
+    sudo rm -rf /var/lib/apt/lists/*
+
 # Configure direnv shell hook and PATH
 RUN echo 'eval "$(direnv hook bash)"' >> ~/.bashrc \
     && echo 'export PIPX_BIN_DIR="$HOME/.local/bin"' >> ~/.bashrc \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,8 +33,10 @@ RUN sudo apt-get update \
     && sudo apt-get install -y \
     avahi-utils \
     bumpversion \
+    curl \
     direnv \
     dnsutils \
+    git \
     inetutils-ping \
     nano \
     net-tools \
@@ -55,7 +57,7 @@ RUN echo 'eval "$(direnv hook bash)"' >> ~/.bashrc \
 
 # Install mutagen
 RUN curl -sS https://webi.sh/mutagen | sh \
-    && source ~/.config/envman/PATH.env
+    && . ~/.config/envman/PATH.env
 
 RUN mkdir -p /home/vscode/.local/bin
 RUN sudo chown -R $USERNAME:$USERNAME /home/$USERNAME

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,6 +41,7 @@ RUN sudo apt-get update \
     inetutils-ping \
     iproute2 \
     libnss3-tools \
+    mr \
     nano \
     net-tools \
     openssh-client \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,7 +34,6 @@ RUN sudo apt-get update \
     avahi-utils \
     bumpversion \
     curl \
-    direnv \
     dnsutils \
     fuse \
     git \
@@ -75,9 +74,7 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     sudo apt-get install -y --no-install-recommends firefox && \
     sudo rm -rf /var/lib/apt/lists/*
 
-# Configure direnv shell hook and PATH
-RUN echo 'eval "$(direnv hook bash)"' >> ~/.bashrc \
-    && echo 'export PIPX_BIN_DIR="$HOME/.local/bin"' >> ~/.bashrc \
+RUN echo 'export PIPX_BIN_DIR="$HOME/.local/bin"' >> ~/.bashrc \
     && echo 'export PATH="$PIPX_BIN_DIR:$PATH"' >> ~/.bashrc
 
 # Install mutagen

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,6 +38,7 @@ RUN sudo apt-get update \
     dnsutils \
     git \
     inetutils-ping \
+    iproute2 \
     nano \
     net-tools \
     openssh-client \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,14 +1,23 @@
-FROM osrf/ros:noetic-desktop-full
+FROM ubuntu:24.04
 
 # Add vscode user with same UID and GID as your host system
 # (copied from https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user#_creating-a-nonroot-user)
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    && apt-get update \
-    && apt-get install -y sudo \
+
+# Create user or modify existing user
+RUN apt-get update && apt-get install -y sudo \
+    && if id $USER_UID >/dev/null 2>&1; then \
+        # User with UID exists, modify it
+        existing_user=$(getent passwd $USER_UID | cut -d: -f1) \
+        && usermod -l $USERNAME -d /home/$USERNAME -m $existing_user \
+        && groupmod -n $USERNAME $(getent group $USER_GID | cut -d: -f1) || true; \
+    else \
+        # Create new user
+        groupadd --gid $USER_GID $USERNAME \
+        && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME; \
+    fi \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 # Switch from root to user
@@ -19,15 +28,6 @@ RUN sudo usermod --append --groups video $USERNAME
 
 # Update all packages
 RUN sudo apt update && sudo apt upgrade -y
-
-# Install Git
-RUN sudo apt install -y git
-
-# Rosdep update
-RUN rosdep update
-
-# Source the ROS setup file
-RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc
 
 RUN sudo apt-get update \
     && sudo apt-get install -y \
@@ -41,11 +41,14 @@ RUN sudo apt-get update \
     rsync \
     unzip \
     pipx \
-    python3.8-venv \
+    python3-venv \
+    build-essential \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Configure direnv shell hook (assuming bash)
+# Configure direnv shell hook and PATH
 RUN echo 'eval "$(direnv hook bash)"' >> ~/.bashrc \
     && echo 'export PIPX_BIN_DIR="$HOME/.local/bin"' >> ~/.bashrc \
-    && echo 'export PATH="$PIPX_BIN_DIR:$PATH"' >> ~/.bashrc \
-    && echo 'export PATH=/home/vscode/.local/bin:$PATH'
+    && echo 'export PATH="$PIPX_BIN_DIR:$PATH"' >> ~/.bashrc
+
+RUN mkdir -p /home/vscode/.local/bin
+RUN sudo chown -R $USERNAME:$USERNAME /home/$USERNAME

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,6 +43,8 @@ RUN sudo apt-get update \
     pipx \
     python3-venv \
     build-essential \
+    gcc \
+    python3-dev \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # Configure direnv shell hook and PATH

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -75,7 +75,7 @@ RUN echo 'eval "$(direnv hook bash)"' >> ~/.bashrc \
 
 # Install mutagen
 RUN curl -sS https://webi.sh/mutagen | sh \
-    && . ~/.config/envman/PATH.env
+    && if [ -f ~/.config/envman/PATH.env ]; then . ~/.config/envman/PATH.env; fi
 
 RUN mkdir -p /home/vscode/.local/bin
 RUN sudo chown -R $USERNAME:$USERNAME /home/$USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "duckietown",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "devcontainer",
+	"workspaceFolder": "/workspaces/dt-env-developer",
 	"features": {
 		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/devcontainers/features/git-lfs:1": {},
@@ -17,7 +18,7 @@
 		"source=${localEnv:HOME}/Library/Application Support/mkcert,target=/caroot,type=bind,consistency=cached,readonly"
 	],
 	"forwardPorts": [6080],
-	"postStartCommand": ".devcontainer/postStartCommand.sh",
+	"postStartCommand": "/workspaces/dt-env-developer/.devcontainer/postStartCommand.sh",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
 		}
 	},
 	"containerEnv": { "CAROOT": "/caroot" },
+	"initializeCommand": "mkdir -p \"$HOME/Library/Application Support/mkcert\"",
 	"mounts": [
 		"source=${localEnv:HOME}/Library/Application Support/mkcert,target=/caroot,type=bind,consistency=cached,readonly"
 	],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "duckietown",
-	"dockerFile": "Dockerfile",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "devcontainer",
 	"features": {
 		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/devcontainers/features/git-lfs:1": {},
@@ -17,7 +18,6 @@
 	],
 	"forwardPorts": [6080],
 	"postStartCommand": ".devcontainer/postStartCommand.sh",
-	"runArgs": ["--net=host"],
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,21 +2,15 @@
 	"name": "noetic desktop",
 	"dockerFile": "Dockerfile",
   	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {
-			"moby": true,
-			"azureDnsAutoDetection": true,
-			"installDockerBuildx": true,
-			"installDockerComposeSwitch": true,
-			"version": "latest",
-			"dockerDashComposeVersion": "latest"
-		},
-		"ghcr.io/devcontainers/features/git:1": {
-			"ppa": true,
-			"version": "os-provided"
-		},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/devcontainers/features/git-lfs:1": {},
-		"ghcr.io/tailscale/codespace/tailscale": {}
+		"ghcr.io/tailscale/codespace/tailscale": {},
+		"ghcr.io/devcontainers/features/desktop-lite:1": {
+			"webPort": 6080
+		}
 	},
+	"forwardPorts": [6080],
 	"postCreateCommand": "pipx install duckietown-shell",
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,10 @@
 			"webPort": 6080
 		}
 	},
+	"containerEnv": { "CAROOT": "/caroot" },
+	"mounts": [
+		"source=${localEnv:HOME}/Library/Application Support/mkcert,target=/caroot,type=bind,consistency=cached,readonly"
+	],
 	"forwardPorts": [6080],
 	"postStartCommand": ".devcontainer/postStartCommand.sh",
 	"runArgs": ["--net=host"],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/devcontainers/features/git-lfs:1": {},
 		"ghcr.io/tailscale/codespace/tailscale": {},
-		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/desktop-lite:1": {
 			"webPort": 6080
 		}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,10 @@
 				"ms-toolsai.jupyter-cell-tags",
 				"ms-toolsai.jupyter-renderers",
 				"ms-toolsai.vscode-jupyter-slideshow"
-			]
+			],
+			"settings": {
+				"dev.containers.dockerCredentialHelper": false,
+			}
 		}
 	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "noetic desktop",
+	"name": "duckietown",
 	"dockerFile": "Dockerfile",
 	"features": {
 		"ghcr.io/devcontainers/features/git:1": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,18 @@
 {
 	"name": "noetic desktop",
 	"dockerFile": "Dockerfile",
-  	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+	"features": {
 		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/devcontainers/features/git-lfs:1": {},
 		"ghcr.io/tailscale/codespace/tailscale": {},
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
 		"ghcr.io/devcontainers/features/desktop-lite:1": {
 			"webPort": 6080
 		}
 	},
 	"forwardPorts": [6080],
-	"postCreateCommand": "pipx install duckietown-shell",
+	"postStartCommand": ".devcontainer/postStartCommand.sh",
+	"runArgs": ["--net=host"],
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  devcontainer:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      # Persist vscode user home directory
+      - vscode-home:/home/vscode
+      # Mount the workspace
+      - ../..:/workspaces:cached
+    
+    command: sleep infinity
+    init: true
+    network_mode: host
+    environment:
+      - DOCKER_BUILDKIT=1
+    security_opt:
+      - seccomp:unconfined
+    privileged: true
+
+volumes:
+  # Named volume to persist vscode home directory
+  vscode-home:
+    driver: local

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     network_mode: host
     environment:
       - DOCKER_BUILDKIT=1
+    tmpfs:
+      - /tmp:rw,exec,size=50g
 
 volumes:
   # Named volume to persist vscode home directory

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,9 +16,6 @@ services:
     network_mode: host
     environment:
       - DOCKER_BUILDKIT=1
-    security_opt:
-      - seccomp:unconfined
-    privileged: true
 
 volumes:
   # Named volume to persist vscode home directory

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -12,3 +12,6 @@ sudo avahi-daemon -D
 # Docker credentials fix
 export DOCKER_CONFIG="$(mktemp -d)"
 printf '{}' > "$DOCKER_CONFIG/config.json"
+
+# Add DOCKER_CONFIG to ~/.bashrc for persistent access
+echo "export DOCKER_CONFIG=\"$DOCKER_CONFIG\"" >> ~/.bashrc

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Install duckietown-shell
+pipx install duckietown-shell
+
+# Create dbus directory
+sudo mkdir -p /var/run/dbus
+
+# Start dbus daemon
+sudo dbus-daemon --system --fork
+
+# Start avahi daemon
+sudo avahi-daemon -D

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -15,3 +15,5 @@ printf '{}' > "$DOCKER_CONFIG/config.json"
 
 # Add DOCKER_CONFIG to ~/.bashrc for persistent access
 echo "export DOCKER_CONFIG=\"$DOCKER_CONFIG\"" >> ~/.bashrc
+
+echo "Setup complete. Please open a new terminal."

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Configure mDNS for fast .local resolution
+sudo sed -i 's/^hosts:.*/hosts: files mdns4_minimal [SUCCESS=return] mdns6_minimal [SUCCESS=return] dns/' /etc/nsswitch.conf
+sudo grep -q "single-request-reopen" /etc/resolv.conf || sudo echo "options timeout:1 attempts:1 single-request-reopen" | sudo tee -a /etc/resolv.conf
 # Install duckietown-shell
 pipx install duckietown-shell
 
@@ -14,6 +17,8 @@ export DOCKER_CONFIG="$(mktemp -d)"
 printf '{}' > "$DOCKER_CONFIG/config.json"
 
 # Add DOCKER_CONFIG to ~/.bashrc for persistent access
-echo "export DOCKER_CONFIG=\"$DOCKER_CONFIG\"" >> ~/.bashrc
+if ! grep -q "export DOCKER_CONFIG=" ~/.bashrc; then
+	echo "export DOCKER_CONFIG=\"$DOCKER_CONFIG\"" >> ~/.bashrc
+fi
 
 echo "Setup complete. Please open a new terminal."

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -2,8 +2,6 @@
 
 # Install duckietown-shell
 pipx install duckietown-shell
-direnv allow /workspaces/*/.envrc
-
 
 # Start dbus daemon
 sudo dbus-daemon --system --fork

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -2,6 +2,7 @@
 
 # Install duckietown-shell
 pipx install duckietown-shell
+direnv allow /workspaces/dt-env-developer/.envrc
 
 # Create dbus directory
 sudo mkdir -p /var/run/dbus

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -8,3 +8,7 @@ sudo dbus-daemon --system --fork
 
 # Start avahi daemon
 sudo avahi-daemon -D
+
+# Docker credentials fix
+export DOCKER_CONFIG="$(mktemp -d)"
+printf '{}' > "$DOCKER_CONFIG/config.json"

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -2,7 +2,7 @@
 
 # Install duckietown-shell
 pipx install duckietown-shell
-direnv allow /workspaces/dt-env-developer/.envrc
+direnv allow /workspaces/*/.envrc
 
 
 # Start dbus daemon

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -4,8 +4,6 @@
 pipx install duckietown-shell
 direnv allow /workspaces/dt-env-developer/.envrc
 
-# Create dbus directory
-sudo mkdir -p /var/run/dbus
 
 # Start dbus daemon
 sudo dbus-daemon --system --fork

--- a/.envrc
+++ b/.envrc
@@ -12,6 +12,7 @@ export DTSHELL_COMMANDS=${ROOT_DIR}/shell/duckietown-shell-commands
 export DTSHELL_VERBOSE=0
 export DTSHELL_PYTHONPATH=${ROOT_DIR}/libraries/lib-dtproject/src 
 export DTSHELL_PROFILE=ente
+export DTSHELL_DISTRO=ente
 
 # python
 # - duckietown-sdk


### PR DESCRIPTION
This pull request updates the development container setup for the project, moving from a ROS Noetic-based image to a more general Ubuntu 24.04 environment and modernizing the devcontainer configuration. The changes improve compatibility, add desktop and browser support, and streamline user and package management. Key improvements include a new Dockerfile base, enhanced package installation, desktop access via browser, and automated post-start setup.

**Container base and user management:**
* Switched the Dockerfile base image from `osrf/ros:noetic-desktop-full` to `ubuntu:24.04`, and improved logic to handle existing users by UID/GID for better compatibility across host systems.

**Package installation and environment setup:**
* Updated package installation to include additional utilities (e.g., `curl`, `fuse`, `openssh-client`, `build-essential`, `python3-dev`, `firefox` from Mozilla repo), replaced `python3.8-venv` with `python3-venv`, and automated installation of `mutagen` via webi.sh.
* Enhanced shell environment setup in `.bashrc` for `direnv` and `pipx`, and ensured correct permissions for user directories.

**Devcontainer configuration:**
* Updated `.devcontainer/devcontainer.json` to use the new "duckietown" container name, enabled desktop access via `desktop-lite` feature (webPort 6080), set up port forwarding, and moved `duckietown-shell` installation to a post-start script for improved reliability.
* Added `runArgs` to use host networking for better network compatibility.

**Post-start automation:**
* Introduced `.devcontainer/postStartCommand.sh` to automate installation of `duckietown-shell`, allow `direnv`, and start essential daemons (`dbus`, `avahi`) for desktop and network service support.

**Environment variable updates:**
* Added `DTSHELL_DISTRO=ente` to `.envrc` to ensure the correct shell distribution is set for the environment.

## Testing

Instructions to use the devcontainer are available [in the duckietown manual](https://docs.duckietown.com/ente/duckietown-manual/10-setup/setup-devcontainer.html).

To test the devcontainer, clone the [lx-ros-basic learning experience](https://github.com/duckietown/lx-ros-basics?tab=readme-ov-file#learning-experience-lx-ros-basics) and follow the instructions in the README of the learning experience.

