### PR TITLE
Fix ssh host agent forwarding

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,34 +1,24 @@
-FROM ubuntu:24.04
+FROM mcr.microsoft.com/devcontainers/base:noble
 
 # Add vscode user with same UID and GID as your host system
-# (copied from https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user#_creating-a-nonroot-user)
+# (from https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user#_creating-a-nonroot-user)
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-# Create user or modify existing user
-RUN apt-get update && apt-get install -y sudo \
-    && if id $USER_UID >/dev/null 2>&1; then \
-        # User with UID exists, modify it
-        existing_user=$(getent passwd $USER_UID | cut -d: -f1) \
-        && usermod -l $USERNAME -d /home/$USERNAME -m $existing_user \
-        && groupmod -n $USERNAME $(getent group $USER_GID | cut -d: -f1) || true; \
-    else \
-        # Create new user
-        groupadd --gid $USER_GID $USERNAME \
-        && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME; \
-    fi \
+# Create the user
+RUN apt-get update \
+    && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
-# Switch from root to user
+
+# Set the default user. 
 USER $USERNAME
 
 # Add user to video group to allow access to webcam
 RUN sudo usermod --append --groups video $USERNAME
 
 # Update all packages
-RUN sudo apt update && sudo apt upgrade -y
-
 RUN sudo apt-get update \
     && sudo apt-get install -y \
     avahi-utils \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"name": "duckietown",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "devcontainer",
-	"workspaceFolder": "/workspaces/dt-env-developer",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 	"features": {
 		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/devcontainers/features/git-lfs:1": {},
@@ -12,11 +12,6 @@
 			"webPort": 6080
 		}
 	},
-	"containerEnv": { "CAROOT": "/caroot" },
-	"initializeCommand": "mkdir -p \"$HOME/Library/Application Support/mkcert\"",
-	"mounts": [
-		"source=${localEnv:HOME}/Library/Application Support/mkcert,target=/caroot,type=bind,consistency=cached,readonly"
-	],
 	"forwardPorts": [6080],
 	"postStartCommand": "/workspaces/dt-env-developer/.devcontainer/postStartCommand.sh",
 	"customizations": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,12 +14,15 @@ services:
       # Mount the workspace
       - ../..:/workspaces:cached
       - /tmp        # Anonymous volume
-
+      # Mount mkcert CA root directory
+      - ${HOME}/Library/Application Support/mkcert:/caroot:ro,cached
+    user: vscode
     command: sleep infinity
     init: true
     network_mode: host
     environment:
       - DOCKER_BUILDKIT=1
+      - CAROOT=/caroot
 
 volumes:
   # Named volume to persist vscode home directory

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -19,9 +19,9 @@ sudo avahi-daemon -D
 export DOCKER_CONFIG="$(mktemp -d)"
 printf '{}' > "$DOCKER_CONFIG/config.json"
 
-# Add DOCKER_CONFIG to ~/.bashrc for persistent access
-if ! grep -q "export DOCKER_CONFIG=" ~/.bashrc; then
-	echo "export DOCKER_CONFIG=\"$DOCKER_CONFIG\"" >> ~/.bashrc
+# Add DOCKER_CONFIG to ~/.zshrc for persistent access
+if ! grep -q "export DOCKER_CONFIG=" ~/.zshrc; then
+	echo "export DOCKER_CONFIG=\"$DOCKER_CONFIG\"" >> ~/.zshrc
 fi
 
 # Check if development mode is enabled and run direnv allow
@@ -29,9 +29,9 @@ if [ "${ENABLE_DEVELOPMENT_MODE}" = "true" ]; then
 	echo "Development mode enabled. Setting up direnv..."
 	
 	# Add direnv hook to bashrc if not already present
-	if ! grep -q 'eval "$(direnv hook bash)"' ~/.bashrc; then
-		echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
-		echo "Direnv hook added to ~/.bashrc"
+	if ! grep -q 'eval "$(direnv hook zsh)"' ~/.zshrc; then
+		echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
+		echo "Direnv hook added to ~/.zshrc"
 	fi
 	
 	# Run direnv allow
@@ -41,10 +41,10 @@ if [ "${ENABLE_DEVELOPMENT_MODE}" = "true" ]; then
 else
 	echo "Development mode not enabled (set ENABLE_DEVELOPMENT_MODE=true in .devcontainer/.env to enable)."
 	
-	# Remove direnv hook from ~/.bashrc if present
-	if grep -q 'eval "$(direnv hook bash)"' ~/.bashrc; then
-		sed -i '/eval "$(direnv hook bash)"/d' ~/.bashrc
-		echo "Direnv hook removed from ~/.bashrc"
+	# Remove direnv hook from ~/.zshrc if present
+	if grep -q 'eval "$(direnv hook zsh)"' ~/.zshrc; then
+		sed -i '/eval "$(direnv hook zsh)"/d' ~/.zshrc
+		echo "Direnv hook removed from ~/.zshrc"
 	fi
 
 	unset SSH_AUTH_SOCK

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -46,6 +46,10 @@ else
 		sed -i '/eval "$(direnv hook bash)"/d' ~/.bashrc
 		echo "Direnv hook removed from ~/.bashrc"
 	fi
+
+	unset SSH_AUTH_SOCK
+	eval "$(ssh-agent -s)"
+	echo "SSH agent started. The container will not have access to your host's SSH keys."
 fi
 
 echo "Setup complete. Please open a new terminal."

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Clear up /tmp directory
-sudo rm -rf /tmp/*
+sudo rm -rf /tmp/duckietown/*
 
 # Configure mDNS for fast .local resolution
 sudo sed -i 's/^hosts:.*/hosts: files mdns4_minimal [SUCCESS=return] mdns6_minimal [SUCCESS=return] dns/' /etc/nsswitch.conf
@@ -47,6 +47,7 @@ else
 		echo "Direnv hook removed from ~/.zshrc"
 	fi
 
+	sudo rm -rf /tmp/vscode-ssh-auth-* # This is a workaround to disable SSH agent forwarding in devcontainers
 	unset SSH_AUTH_SOCK
 	eval "$(ssh-agent -s)"
 	echo "SSH agent started. The container will not have access to your host's SSH keys."


### PR DESCRIPTION
I have fixed ssh host agent forwarding for developer mode. This streamlines development by reusing the host SSH config.

Testing should be simply using this branch in the day to day when running the lxs etc.

Also by setting the `ENABLE_DEVELOPMENT_MODE` variable to `true` in the `.devcontainer/.env` file and rebuilding you will be able to use the host system ssh keys.

Refer to the instructions to enable developer mode in the README.md for more details.

Test setting up new ssh keys with `ENABLE_DEVELOPMENT_MODE` set to 'false' in a freshly rebuilt devcontainer, clone an lx and verify that you can run it.