### PR TITLE
feat: override MKCert CA certificate using host environment variable

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ../..:/workspaces:cached
       - /tmp        # Anonymous volume
       # Mount mkcert CA root directory
-      - ${HOME}/Library/Application Support/mkcert:/caroot:ro,cached
+      - ${MKCERT_PATH:-${HOME}/Library/Application Support/mkcert}:/caroot:ro,cached
     user: vscode
     command: sleep infinity
     init: true


### PR DESCRIPTION
This pull request updates the Docker Compose configuration to make the mount path for the mkcert CA root directory configurable via the `MKCERT_PATH` environment variable. This change improves flexibility for developers who may have custom mkcert installation paths and enables using the same devcontainer file on multiple platforms.