### PR TITLE
fix(DTSW-7780): make devcontainer avahi-daemon start idempotent so mDNS self-heals

### DIFF
--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -12,7 +12,10 @@ pipx install duckietown-shell
 # Start dbus daemon
 sudo dbus-daemon --system --fork
 
-# Start avahi daemon
+# Start avahi daemon (idempotent: if a previous instance crashed and its pid got
+# recycled, the stale pidfile blocks restart — clear it out first)
+sudo pkill -x avahi-daemon 2>/dev/null || true
+sudo rm -f /var/run/avahi-daemon/pid
 sudo avahi-daemon -D
 
 # Docker credentials fix


### PR DESCRIPTION
## Summary
- `postStartCommand.sh` now kills any stale `avahi-daemon` and removes `/var/run/avahi-daemon/pid` before starting avahi.
- Prevents the case where a previous avahi crashed, its PID got recycled by another process (e.g. `containerd`), and the stale pidfile blocked fresh startup — silently breaking `ping <robot>.local` inside the devcontainer until manual cleanup.

## Jira
DTSW-7780

## Test plan
- [ ] Rebuild devcontainer, verify `ping testdrone.local` resolves.
- [ ] Kill avahi inside a running container, re-run `postStartCommand.sh`, verify it comes back without manual pidfile cleanup.